### PR TITLE
[codex] Define personal site direction and content model

### DIFF
--- a/docs/personal-site-direction.md
+++ b/docs/personal-site-direction.md
@@ -1,0 +1,46 @@
+# Personal Site Direction and Content Model
+
+This document defines the first public content direction for the personal site before the homepage is rewritten. It keeps the first release intentionally small and public-safe.
+
+## Audience
+
+The site should primarily serve:
+
+- Recruiters who need a fast read on professional focus, technical range, and contact paths.
+- Engineering peers who want to understand the kind of systems, standards, and craft represented by the work.
+
+## Direction
+
+The first version should feel sleek, professional, and specific to Stephen Darcy without relying on employment-specific project detail.
+
+The homepage should answer one clear question quickly: what kind of engineer is this? Useful public-safe examples for the opening slice include:
+
+- `Stephen Darcy builds production-shaped software across frontend, backend, cloud, and automation.`
+- `Stephen Darcy is a software engineer focused on polished interfaces, reliable services, and secure delivery practices.`
+- `Stephen Darcy works across TypeScript, Java, Spring Boot, AWS-oriented architecture, CI/CD, and observability.`
+
+The exact homepage line can change in Issue #2, but it should stay factual, direct, and easy to scan.
+
+## Initial Content Model
+
+Keep the first release intentionally tiny:
+
+- `Hero`: full name, short professional positioning, and links to GitHub and LinkedIn.
+- `About`: concise professional summary focused on engineering style, technical range, and public-safe interests.
+- `Stack`: a compact list of technologies and practices that are safe to mention publicly, including TypeScript, Next.js, Java, Spring Boot, OpenAPI, AWS-oriented deployment, Docker, GitHub Actions, testing, security hygiene, and observability.
+- `Contact`: GitHub and LinkedIn as the initial contact routes.
+
+Do not add selected work, project case studies, screenshots, metrics, employment-specific implementation details, private systems, family/private material, or direct personal contact details until they are intentionally prepared for public use.
+
+## Homepage Guidance for Issue #2
+
+The next homepage PR should introduce Stephen first. It should not start with a project gallery.
+
+Good first-slice patterns:
+
+- Name plus professional positioning.
+- Short builder statement with public-safe technology range.
+- GitHub and LinkedIn actions.
+- One compact support section for stack or working principles.
+
+The homepage should avoid generic portfolio filler, oversized claims, and placeholders. It should read as a small but finished professional first slice.


### PR DESCRIPTION
﻿## Summary

Adds a concise direction and content model document for the personal site before changing the homepage.

This captures the Issue #1 decisions from the initial quiz:

- Primary audiences are recruiters and engineering peers.
- Tone should be sleek, professional, factual, and public-safe.
- The first version should stay intentionally tiny: hero, about, stack, and contact.
- Contact routes start with GitHub and LinkedIn.
- Selected work and project case studies stay out of the first slice unless later prepared for public use.
- Issue #2 should introduce Stephen first rather than starting with a project gallery.

Closes #1.

## Verification

- `git status --short --branch`
- `git pull --ff-only`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/security/preflight.ps1 -Scope Repository`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/security/preflight.ps1 -Scope Staged`

Frontend lint/typecheck/build were not run because this PR only adds documentation and does not touch `frontend/`.

## Visual Evidence

No UI changes. Homepage changes are intentionally deferred to Issue #2.

## Security and Operations

- No secrets, credentials, real account IDs, or unsafe examples are included.
- Public-facing copy is intentionally prepared for this site.
- This work used the dedicated branch `codex/site-direction-content-model`.
- No app boundary, data flow, hosting, or security posture changed.
