### PR TITLE
[codex] Add public content inventory

### DIFF
--- a/docs/public-content-inventory.md
+++ b/docs/public-content-inventory.md
@@ -1,0 +1,85 @@
+# Public Content Inventory
+
+This inventory tracks content that may be used on the public site. It separates approved public-safe facts from candidates that need rewriting or evidence before they are published.
+
+## Status Key
+
+- `ready to publish`: approved for the first public site slice as written.
+- `needs rewriting`: plausible public content, but it needs tighter wording, evidence, or explicit approval before use.
+- `not for v1`: excluded from the first release.
+
+## Confirmed Public-Safe Facts
+
+| Item | Public wording | Status | Evidence or review need |
+| --- | --- | --- | --- |
+| Name | Stephen Darcy | ready to publish | User-approved. |
+| Location | Dublin, Ireland | ready to publish | User-approved. |
+| Role/title | Full-stack software engineer | ready to publish | User-approved direction; avoids current company or internal role detail. |
+| Experience | 4 years of professional experience | ready to publish | User-approved. |
+| GitHub | `https://github.com/StephenDarcy` | ready to publish | User-approved. |
+| LinkedIn | `https://www.linkedin.com/in/stephen-darcy-0871141b8/` | ready to publish | User-approved. |
+
+## Homepage Copy Candidates
+
+| Candidate | Status | Notes |
+| --- | --- | --- |
+| Stephen Darcy is a full-stack software engineer in Dublin, Ireland, building polished interfaces, reliable services, and cloud-ready delivery paths. | needs rewriting | Strong v1 candidate. Confirm exact tone before publishing. |
+| I work across frontend, Java services, AWS-oriented delivery, and the engineering practices that keep software maintainable. | needs rewriting | Useful about-section candidate. Confirm first-person style before publishing. |
+| I like building software that feels considered from the interface down to the delivery pipeline. | needs rewriting | Human, public-safe, and not tied to any company-specific detail. Confirm whether this feels like Stephen. |
+| Personal interests, including the dog reference. | not for v1 | Can be added later if Stephen wants a more personal about section. Needs exact wording and tone approval first. |
+
+## Skills and Stack
+
+| Item | Public wording | Status | Evidence or review need |
+| --- | --- | --- | --- |
+| Frontend | Frontend engineering | ready to publish | User-approved. |
+| Java | Java | ready to publish | User-approved. |
+| Spring | Spring and Spring Boot | ready to publish | User-approved. |
+| AWS | AWS-oriented cloud delivery | ready to publish | User-approved; keep wording general. |
+| React | React | ready to publish | User-approved. |
+| Angular | Angular | ready to publish | User-approved. |
+| CI/CD | CI/CD | ready to publish | User-approved. |
+| Accessibility | Accessibility | ready to publish | User-approved as `a11y`; expand for public readability. |
+| Observability | Observability | ready to publish | User-approved as `o11y`; expand for public readability. |
+| Kubernetes | Kubernetes | ready to publish | User-approved as `k8s`; expand for public readability. |
+| Developer automation tooling | Developer automation tooling | needs rewriting | User mentioned this area, but exact public wording needs approval before site copy. |
+
+## Projects and Case Studies
+
+| Item | Status | Evidence or review need |
+| --- | --- | --- |
+| Public project case studies | not for v1 | Stephen confirmed there are no prepared public case studies for the first release. |
+| Selected work section | not for v1 | Keep out of v1 unless specific public-safe projects are prepared later. |
+| Screenshots of project work | not for v1 | Do not add screenshots until they are intentionally prepared for public use. |
+| Metrics, achievements, clients, or delivery claims | not for v1 | No approved public wording or supporting evidence provided. |
+
+## Work-Related Content
+
+| Item | Status | Evidence or review need |
+| --- | --- | --- |
+| Company names | not for v1 | Explicitly excluded from public site content. |
+| Current job title or internal role split | not for v1 | Use the public title `Full-stack software engineer` instead. |
+| Client, system, architecture, or delivery details from paid work | not for v1 | Exclude unless rewritten and explicitly approved for public use. |
+| Public-safe career summary without company detail | needs rewriting | Candidate only; must stay neutral, factual, and non-specific. |
+
+## Links
+
+| Link | Status | Evidence or review need |
+| --- | --- | --- |
+| GitHub profile | ready to publish | `https://github.com/StephenDarcy` |
+| LinkedIn profile | ready to publish | `https://www.linkedin.com/in/stephen-darcy-0871141b8/` |
+| Other public links | not for v1 | No other links approved. |
+
+## Evidence Needs
+
+| Evidence item | Status | Notes |
+| --- | --- | --- |
+| Homepage screenshots | ready to publish | Existing visual evidence lives in `docs/visual-evidence/` and supports the first homepage slice. |
+| Public profile links | ready to publish | GitHub and LinkedIn URLs approved. |
+| Project screenshots | not for v1 | No prepared public projects or case studies. |
+| Claims beyond the approved facts and stack list | needs rewriting | Require supporting evidence before publishing. |
+| Short bio wording | needs rewriting | Pick one candidate, revise, and approve before using it on the site. |
+
+## V1 Publishing Boundary
+
+For v1, the public site may use the approved facts, GitHub and LinkedIn links, and compact stack wording above. It should not include project galleries, case studies, company names, company-specific details, metrics, client references, screenshots from private work, or claims that have not been reviewed.


### PR DESCRIPTION
## Summary

Adds `docs/public-content-inventory.md` for Issue #3.

The inventory separates confirmed public-safe facts from candidates that need rewriting and items that are not for v1. It covers approved links, stack wording, homepage copy candidates, project/case-study boundaries, evidence needs, and the v1 publishing boundary.

## Scope

- Documentation only.
- No frontend, backend, contract, or infrastructure changes.
- No project, employer, client, metric, screenshot, or achievement claims were invented.

## Verification

- Ran `powershell -ExecutionPolicy Bypass -File scripts\security\preflight.ps1 -Scope Repository`.
- Ran `powershell -ExecutionPolicy Bypass -File scripts\security\preflight.ps1 -Scope Staged`.
- Skipped frontend lint/typecheck/build because this PR is docs-only and does not touch frontend code.

Closes #3.