### PR TITLE
[codex] Scaffold backend runtime status slice

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,13 +1,13 @@
 # Backend
 
-This directory will contain the public Spring Boot API.
+This directory contains the public Spring Boot API.
 
 ## Ownership
 
-- Framework: Spring Boot.
+- Framework: Spring Boot 3.5.x.
 - Runtime: Java 21.
 - Build: Maven.
-- Packaging: containerized runtime from the first backend scaffold.
+- Packaging: executable Spring Boot jar. Container packaging should be added with the matching container scan gate before a Dockerfile is introduced.
 
 ## Boundaries
 
@@ -17,8 +17,48 @@ This directory will contain the public Spring Boot API.
 - Do not store durable visitor-submitted data or add private authenticated areas without an ADR and threat-model update.
 - Keep sample configuration obviously fake and free of real secrets, credentials, and account IDs.
 
-## Next Implementation Step
+## Runtime Status API
 
-The next backend PR should implement the public runtime status slice from [ADR 0009](../docs/adr/0009-first-backend-vertical-slice.md): Spring Boot scaffold, `GET /api/v1/health`, `GET /api/v1/version`, structured errors, request correlation, narrow CORS, Maven verification, Docker build path, and CI coverage.
+The first backend slice implements the public runtime status boundary from [ADR 0009](../docs/adr/0009-first-backend-vertical-slice.md):
+
+- `GET /api/v1/health`
+- `GET /api/v1/version`
+- structured public-safe errors
+- request correlation through `X-Correlation-ID`
+- narrow CORS for the intended local frontend origin
+
+Both endpoints are read-only and accept no request body, query parameters, or path parameters.
 
 Do not add product data, persistence, authentication, contact workflows, analytics collection, or other visitor-submitted data in this slice.
+
+## Local Verification
+
+From the repository root:
+
+```powershell
+cd backend
+mvn --batch-mode verify
+```
+
+Run the API locally:
+
+```powershell
+cd backend
+mvn --batch-mode spring-boot:run
+```
+
+Build a local container image with Spring Boot buildpacks:
+
+```powershell
+cd backend
+mvn --batch-mode spring-boot:build-image -Dspring-boot.build-image.imageName=personal-api:local
+```
+
+The image command requires a local Docker-compatible runtime. Do not add a Dockerfile until container scanning is wired into the repository security gates.
+
+Example local checks:
+
+```powershell
+Invoke-RestMethod -Uri "http://localhost:8080/api/v1/health" -Headers @{ "X-Correlation-ID" = "req_20260115_103000_demo" }
+Invoke-RestMethod -Uri "http://localhost:8080/api/v1/version"
+```

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.14</version>
+        <relativePath />
+    </parent>
+
+    <groupId>com.stephendarcy</groupId>
+    <artifactId>personal-api</artifactId>
+    <version>0.1.0</version>
+    <name>personal-api</name>
+    <description>Public runtime status API for the personal site backend.</description>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/backend/src/main/java/com/stephendarcy/personal/PersonalApiApplication.java
+++ b/backend/src/main/java/com/stephendarcy/personal/PersonalApiApplication.java
@@ -1,0 +1,14 @@
+package com.stephendarcy.personal;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+
+@SpringBootApplication
+@ConfigurationPropertiesScan
+public class PersonalApiApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(PersonalApiApplication.class, args);
+    }
+}

--- a/backend/src/main/java/com/stephendarcy/personal/runtime/HealthResponse.java
+++ b/backend/src/main/java/com/stephendarcy/personal/runtime/HealthResponse.java
@@ -1,0 +1,10 @@
+package com.stephendarcy.personal.runtime;
+
+import java.time.Instant;
+
+public record HealthResponse(
+    String status,
+    String serviceName,
+    Instant checkedAt
+) {
+}

--- a/backend/src/main/java/com/stephendarcy/personal/runtime/RuntimeStatusController.java
+++ b/backend/src/main/java/com/stephendarcy/personal/runtime/RuntimeStatusController.java
@@ -1,0 +1,36 @@
+package com.stephendarcy.personal.runtime;
+
+import java.time.Clock;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = "/api/v1", produces = MediaType.APPLICATION_JSON_VALUE)
+public class RuntimeStatusController {
+
+    private final Clock clock;
+    private final RuntimeStatusProperties properties;
+
+    public RuntimeStatusController(Clock clock, RuntimeStatusProperties properties) {
+        this.clock = clock;
+        this.properties = properties;
+    }
+
+    @GetMapping("/health")
+    HealthResponse getHealth() {
+        return new HealthResponse("ready", properties.serviceName(), clock.instant());
+    }
+
+    @GetMapping("/version")
+    VersionResponse getVersion() {
+        return new VersionResponse(
+            properties.serviceName(),
+            properties.version(),
+            properties.buildTimestamp(),
+            properties.commitSha()
+        );
+    }
+}

--- a/backend/src/main/java/com/stephendarcy/personal/runtime/RuntimeStatusProperties.java
+++ b/backend/src/main/java/com/stephendarcy/personal/runtime/RuntimeStatusProperties.java
@@ -1,0 +1,21 @@
+package com.stephendarcy.personal.runtime;
+
+import java.time.Instant;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "app.runtime")
+public record RuntimeStatusProperties(
+    @NotBlank @Size(max = 80) String serviceName,
+    @NotBlank @Pattern(regexp = "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$") String version,
+    @NotNull Instant buildTimestamp,
+    @NotBlank @Pattern(regexp = "^[a-f0-9]{40}$") String commitSha
+) {
+}

--- a/backend/src/main/java/com/stephendarcy/personal/runtime/VersionResponse.java
+++ b/backend/src/main/java/com/stephendarcy/personal/runtime/VersionResponse.java
@@ -1,0 +1,11 @@
+package com.stephendarcy.personal.runtime;
+
+import java.time.Instant;
+
+public record VersionResponse(
+    String serviceName,
+    String version,
+    Instant buildTimestamp,
+    String commitSha
+) {
+}

--- a/backend/src/main/java/com/stephendarcy/personal/web/ApiCorsProperties.java
+++ b/backend/src/main/java/com/stephendarcy/personal/web/ApiCorsProperties.java
@@ -1,0 +1,13 @@
+package com.stephendarcy.personal.web;
+
+import jakarta.validation.constraints.NotBlank;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "app.cors")
+public record ApiCorsProperties(
+    @NotBlank String allowedOrigin
+) {
+}

--- a/backend/src/main/java/com/stephendarcy/personal/web/ApiErrorFactory.java
+++ b/backend/src/main/java/com/stephendarcy/personal/web/ApiErrorFactory.java
@@ -1,0 +1,41 @@
+package com.stephendarcy.personal.web;
+
+import java.util.List;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApiErrorFactory {
+
+    public ApiErrorResponse create(
+        HttpServletRequest request,
+        HttpStatus status,
+        String type,
+        String title,
+        String detail
+    ) {
+        return create(request, status, type, title, detail, List.of());
+    }
+
+    public ApiErrorResponse create(
+        HttpServletRequest request,
+        HttpStatus status,
+        String type,
+        String title,
+        String detail,
+        List<FieldErrorDetail> errors
+    ) {
+        return new ApiErrorResponse(
+            type,
+            title,
+            status.value(),
+            detail,
+            request.getRequestURI(),
+            CorrelationIds.current(request),
+            errors
+        );
+    }
+}

--- a/backend/src/main/java/com/stephendarcy/personal/web/ApiErrorResponse.java
+++ b/backend/src/main/java/com/stephendarcy/personal/web/ApiErrorResponse.java
@@ -1,0 +1,17 @@
+package com.stephendarcy.personal.web;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ApiErrorResponse(
+    String type,
+    String title,
+    int status,
+    String detail,
+    String instance,
+    String correlationId,
+    List<FieldErrorDetail> errors
+) {
+}

--- a/backend/src/main/java/com/stephendarcy/personal/web/ApiErrorWriter.java
+++ b/backend/src/main/java/com/stephendarcy/personal/web/ApiErrorWriter.java
@@ -1,0 +1,55 @@
+package com.stephendarcy.personal.web;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApiErrorWriter {
+
+    private final ApiErrorFactory errorFactory;
+    private final ObjectMapper objectMapper;
+
+    public ApiErrorWriter(ApiErrorFactory errorFactory, ObjectMapper objectMapper) {
+        this.errorFactory = errorFactory;
+        this.objectMapper = objectMapper;
+    }
+
+    public void write(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        HttpStatus status,
+        String type,
+        String title,
+        String detail
+    ) throws IOException {
+        write(request, response, status, type, title, detail, List.of());
+    }
+
+    public void write(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        HttpStatus status,
+        String type,
+        String title,
+        String detail,
+        List<FieldErrorDetail> errors
+    ) throws IOException {
+        String correlationId = CorrelationIds.current(request);
+        response.setStatus(status.value());
+        response.setHeader(CorrelationIds.HEADER, correlationId);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(
+            response.getOutputStream(),
+            errorFactory.create(request, status, type, title, detail, errors)
+        );
+    }
+}

--- a/backend/src/main/java/com/stephendarcy/personal/web/ApiExceptionHandler.java
+++ b/backend/src/main/java/com/stephendarcy/personal/web/ApiExceptionHandler.java
@@ -1,0 +1,151 @@
+package com.stephendarcy.personal.web;
+
+import java.util.List;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+@RestControllerAdvice
+public class ApiExceptionHandler {
+
+    private final ApiErrorFactory errorFactory;
+
+    public ApiExceptionHandler(ApiErrorFactory errorFactory) {
+        this.errorFactory = errorFactory;
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    ResponseEntity<ApiErrorResponse> handleNoHandler(NoHandlerFoundException ex, HttpServletRequest request) {
+        return error(
+            request,
+            HttpStatus.NOT_FOUND,
+            "request.not-found",
+            "Route not found",
+            "No public API route matched the request path."
+        );
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    ResponseEntity<ApiErrorResponse> handleNoResource(NoResourceFoundException ex, HttpServletRequest request) {
+        return error(
+            request,
+            HttpStatus.NOT_FOUND,
+            "request.not-found",
+            "Route not found",
+            "No public API route matched the request path."
+        );
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    ResponseEntity<ApiErrorResponse> handleMethodNotAllowed(
+        HttpRequestMethodNotSupportedException ex,
+        HttpServletRequest request
+    ) {
+        return error(
+            request,
+            HttpStatus.METHOD_NOT_ALLOWED,
+            "request.method-not-allowed",
+            "Method not allowed",
+            "The requested method is not supported for this public API route."
+        );
+    }
+
+    @ExceptionHandler(HttpMediaTypeNotAcceptableException.class)
+    ResponseEntity<ApiErrorResponse> handleNotAcceptable(
+        HttpMediaTypeNotAcceptableException ex,
+        HttpServletRequest request
+    ) {
+        return error(
+            request,
+            HttpStatus.NOT_ACCEPTABLE,
+            "request.not-acceptable",
+            "Response format not supported",
+            "This endpoint returns application/json responses."
+        );
+    }
+
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    ResponseEntity<ApiErrorResponse> handleUnsupportedMediaType(
+        HttpMediaTypeNotSupportedException ex,
+        HttpServletRequest request
+    ) {
+        return error(
+            request,
+            HttpStatus.UNSUPPORTED_MEDIA_TYPE,
+            "request.unsupported-media-type",
+            "Request content type not supported",
+            "This read-only endpoint does not accept a request body."
+        );
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    ResponseEntity<ApiErrorResponse> handleValidation(MethodArgumentNotValidException ex, HttpServletRequest request) {
+        List<FieldErrorDetail> fieldErrors = ex.getBindingResult().getFieldErrors().stream()
+            .map(this::toFieldError)
+            .toList();
+        return error(
+            request,
+            HttpStatus.BAD_REQUEST,
+            "request.validation-failed",
+            "Request validation failed",
+            "The request did not satisfy the public API contract.",
+            fieldErrors
+        );
+    }
+
+    @ExceptionHandler(Exception.class)
+    ResponseEntity<ApiErrorResponse> handleUnexpected(Exception ex, HttpServletRequest request) {
+        return error(
+            request,
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "runtime.internal-error",
+            "Request could not be completed",
+            "The server could not complete the request."
+        );
+    }
+
+    private FieldErrorDetail toFieldError(FieldError error) {
+        return new FieldErrorDetail(error.getField(), "The supplied value is not accepted.");
+    }
+
+    private ResponseEntity<ApiErrorResponse> error(
+        HttpServletRequest request,
+        HttpStatus status,
+        String type,
+        String title,
+        String detail
+    ) {
+        return error(request, status, type, title, detail, List.of());
+    }
+
+    private ResponseEntity<ApiErrorResponse> error(
+        HttpServletRequest request,
+        HttpStatus status,
+        String type,
+        String title,
+        String detail,
+        List<FieldErrorDetail> errors
+    ) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set(CorrelationIds.HEADER, CorrelationIds.current(request));
+        return new ResponseEntity<>(
+            errorFactory.create(request, status, type, title, detail, errors),
+            headers,
+            status
+        );
+    }
+}

--- a/backend/src/main/java/com/stephendarcy/personal/web/ApiExceptionHandler.java
+++ b/backend/src/main/java/com/stephendarcy/personal/web/ApiExceptionHandler.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -20,6 +22,8 @@ import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @RestControllerAdvice
 public class ApiExceptionHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApiExceptionHandler.class);
 
     private final ApiErrorFactory errorFactory;
 
@@ -113,6 +117,12 @@ public class ApiExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     ResponseEntity<ApiErrorResponse> handleUnexpected(Exception ex, HttpServletRequest request) {
+        LOGGER.error(
+            "Unexpected API request failure. correlationId={} path={}",
+            CorrelationIds.current(request),
+            request.getRequestURI(),
+            ex
+        );
         return error(
             request,
             HttpStatus.INTERNAL_SERVER_ERROR,

--- a/backend/src/main/java/com/stephendarcy/personal/web/ApiExceptionHandler.java
+++ b/backend/src/main/java/com/stephendarcy/personal/web/ApiExceptionHandler.java
@@ -54,8 +54,13 @@ public class ApiExceptionHandler {
         HttpRequestMethodNotSupportedException ex,
         HttpServletRequest request
     ) {
+        HttpHeaders headers = errorHeaders(request);
+        if (ex.getSupportedHttpMethods() != null) {
+            headers.setAllow(ex.getSupportedHttpMethods());
+        }
         return error(
             request,
+            headers,
             HttpStatus.METHOD_NOT_ALLOWED,
             "request.method-not-allowed",
             "Method not allowed",
@@ -139,13 +144,40 @@ public class ApiExceptionHandler {
         String detail,
         List<FieldErrorDetail> errors
     ) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.set(CorrelationIds.HEADER, CorrelationIds.current(request));
+        return error(request, errorHeaders(request), status, type, title, detail, errors);
+    }
+
+    private ResponseEntity<ApiErrorResponse> error(
+        HttpServletRequest request,
+        HttpHeaders headers,
+        HttpStatus status,
+        String type,
+        String title,
+        String detail
+    ) {
+        return error(request, headers, status, type, title, detail, List.of());
+    }
+
+    private ResponseEntity<ApiErrorResponse> error(
+        HttpServletRequest request,
+        HttpHeaders headers,
+        HttpStatus status,
+        String type,
+        String title,
+        String detail,
+        List<FieldErrorDetail> errors
+    ) {
         return new ResponseEntity<>(
             errorFactory.create(request, status, type, title, detail, errors),
             headers,
             status
         );
+    }
+
+    private HttpHeaders errorHeaders(HttpServletRequest request) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set(CorrelationIds.HEADER, CorrelationIds.current(request));
+        return headers;
     }
 }

--- a/backend/src/main/java/com/stephendarcy/personal/web/ApiWebConfiguration.java
+++ b/backend/src/main/java/com/stephendarcy/personal/web/ApiWebConfiguration.java
@@ -1,0 +1,34 @@
+package com.stephendarcy.personal.web;
+
+import java.time.Clock;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class ApiWebConfiguration implements WebMvcConfigurer {
+
+    private final ApiCorsProperties corsProperties;
+
+    public ApiWebConfiguration(ApiCorsProperties corsProperties) {
+        this.corsProperties = corsProperties;
+    }
+
+    @Bean
+    Clock clock() {
+        return Clock.systemUTC();
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+            .allowedOrigins(corsProperties.allowedOrigin())
+            .allowedMethods("GET", "OPTIONS")
+            .allowedHeaders(HttpHeaders.ACCEPT, HttpHeaders.CONTENT_TYPE, CorrelationIds.HEADER)
+            .exposedHeaders(CorrelationIds.HEADER)
+            .maxAge(300);
+    }
+}

--- a/backend/src/main/java/com/stephendarcy/personal/web/ApiWebConfiguration.java
+++ b/backend/src/main/java/com/stephendarcy/personal/web/ApiWebConfiguration.java
@@ -1,15 +1,19 @@
 package com.stephendarcy.personal.web;
 
 import java.time.Clock;
+import java.util.List;
 
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import org.springframework.http.HttpHeaders;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
 
 @Configuration
-public class ApiWebConfiguration implements WebMvcConfigurer {
+public class ApiWebConfiguration {
 
     private final ApiCorsProperties corsProperties;
 
@@ -22,13 +26,20 @@ public class ApiWebConfiguration implements WebMvcConfigurer {
         return Clock.systemUTC();
     }
 
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/api/**")
-            .allowedOrigins(corsProperties.allowedOrigin())
-            .allowedMethods("GET", "OPTIONS")
-            .allowedHeaders(HttpHeaders.ACCEPT, HttpHeaders.CONTENT_TYPE, CorrelationIds.HEADER)
-            .exposedHeaders(CorrelationIds.HEADER)
-            .maxAge(300);
+    @Bean
+    FilterRegistrationBean<CorsFilter> apiCorsFilter() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of(corsProperties.allowedOrigin()));
+        configuration.setAllowedMethods(List.of("GET", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of(HttpHeaders.ACCEPT, HttpHeaders.CONTENT_TYPE, CorrelationIds.HEADER));
+        configuration.setExposedHeaders(List.of(CorrelationIds.HEADER));
+        configuration.setMaxAge(300L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/api/**", configuration);
+
+        FilterRegistrationBean<CorsFilter> registration = new FilterRegistrationBean<>(new CorsFilter(source));
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return registration;
     }
 }

--- a/backend/src/main/java/com/stephendarcy/personal/web/ApiWebConfiguration.java
+++ b/backend/src/main/java/com/stephendarcy/personal/web/ApiWebConfiguration.java
@@ -30,7 +30,7 @@ public class ApiWebConfiguration {
     FilterRegistrationBean<CorsFilter> apiCorsFilter() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(List.of(corsProperties.allowedOrigin()));
-        configuration.setAllowedMethods(List.of("GET", "OPTIONS"));
+        configuration.setAllowedMethods(List.of("GET", "HEAD", "OPTIONS"));
         configuration.setAllowedHeaders(List.of(HttpHeaders.ACCEPT, HttpHeaders.CONTENT_TYPE, CorrelationIds.HEADER));
         configuration.setExposedHeaders(List.of(CorrelationIds.HEADER));
         configuration.setMaxAge(300L);

--- a/backend/src/main/java/com/stephendarcy/personal/web/CorrelationFilter.java
+++ b/backend/src/main/java/com/stephendarcy/personal/web/CorrelationFilter.java
@@ -1,0 +1,63 @@
+package com.stephendarcy.personal.web;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class CorrelationFilter extends OncePerRequestFilter {
+
+    private final ApiErrorWriter errorWriter;
+
+    public CorrelationFilter(ApiErrorWriter errorWriter) {
+        this.errorWriter = errorWriter;
+    }
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+        List<String> suppliedValues = Collections.list(request.getHeaders(CorrelationIds.HEADER));
+        if (suppliedValues.isEmpty()) {
+            setCorrelationId(request, response, CorrelationIds.generate());
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (suppliedValues.size() != 1 || !CorrelationIds.isValid(suppliedValues.getFirst())) {
+            setCorrelationId(request, response, CorrelationIds.generate());
+            errorWriter.write(
+                request,
+                response,
+                HttpStatus.BAD_REQUEST,
+                "request.invalid-header",
+                "Invalid request header",
+                "The supplied correlation identifier is not in an accepted format.",
+                List.of(new FieldErrorDetail(CorrelationIds.HEADER, CorrelationIds.VALIDATION_MESSAGE))
+            );
+            return;
+        }
+
+        setCorrelationId(request, response, suppliedValues.getFirst());
+        filterChain.doFilter(request, response);
+    }
+
+    private void setCorrelationId(HttpServletRequest request, HttpServletResponse response, String correlationId) {
+        request.setAttribute(CorrelationIds.ATTRIBUTE, correlationId);
+        response.setHeader(CorrelationIds.HEADER, correlationId);
+    }
+}

--- a/backend/src/main/java/com/stephendarcy/personal/web/CorrelationFilter.java
+++ b/backend/src/main/java/com/stephendarcy/personal/web/CorrelationFilter.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Component
-@Order(Ordered.HIGHEST_PRECEDENCE)
+@Order(Ordered.HIGHEST_PRECEDENCE + 1)
 public class CorrelationFilter extends OncePerRequestFilter {
 
     private final ApiErrorWriter errorWriter;

--- a/backend/src/main/java/com/stephendarcy/personal/web/CorrelationIds.java
+++ b/backend/src/main/java/com/stephendarcy/personal/web/CorrelationIds.java
@@ -1,0 +1,35 @@
+package com.stephendarcy.personal.web;
+
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public final class CorrelationIds {
+
+    public static final String HEADER = "X-Correlation-ID";
+    public static final String ATTRIBUTE = CorrelationIds.class.getName() + ".value";
+    public static final String VALIDATION_MESSAGE =
+        "Use 8 to 128 characters from letters, numbers, dot, underscore, colon, or hyphen.";
+
+    private static final Pattern ACCEPTED = Pattern.compile("^[A-Za-z0-9._:-]{8,128}$");
+
+    private CorrelationIds() {
+    }
+
+    public static boolean isValid(String value) {
+        return value != null && ACCEPTED.matcher(value).matches();
+    }
+
+    public static String generate() {
+        return "req_" + UUID.randomUUID();
+    }
+
+    public static String current(HttpServletRequest request) {
+        Object value = request.getAttribute(ATTRIBUTE);
+        if (value instanceof String correlationId && isValid(correlationId)) {
+            return correlationId;
+        }
+        return generate();
+    }
+}

--- a/backend/src/main/java/com/stephendarcy/personal/web/FieldErrorDetail.java
+++ b/backend/src/main/java/com/stephendarcy/personal/web/FieldErrorDetail.java
@@ -1,0 +1,7 @@
+package com.stephendarcy.personal.web;
+
+public record FieldErrorDetail(
+    String field,
+    String message
+) {
+}

--- a/backend/src/main/java/com/stephendarcy/personal/web/RuntimeStatusRequestValidationFilter.java
+++ b/backend/src/main/java/com/stephendarcy/personal/web/RuntimeStatusRequestValidationFilter.java
@@ -86,7 +86,9 @@ public class RuntimeStatusRequestValidationFilter extends OncePerRequestFilter {
     }
 
     private boolean isRuntimeStatusPath(HttpServletRequest request) {
-        String path = request.getRequestURI();
+        String requestPath = request.getRequestURI();
+        String contextPath = request.getContextPath();
+        String path = contextPath.isBlank() ? requestPath : requestPath.substring(contextPath.length());
         return "/api/v1/health".equals(path) || "/api/v1/version".equals(path);
     }
 
@@ -98,15 +100,44 @@ public class RuntimeStatusRequestValidationFilter extends OncePerRequestFilter {
 
         try {
             List<MediaType> requestedTypes = MediaType.parseMediaTypes(acceptHeaders);
-            return requestedTypes.stream().anyMatch((requestedType) ->
-                requestedType.getQualityValue() > 0.0
-                    && (requestedType.includes(MediaType.APPLICATION_JSON)
-                        || requestedType.isCompatibleWith(MediaType.APPLICATION_JSON))
-            );
+            return qualityForJson(requestedTypes) > 0.0;
         }
         catch (InvalidMediaTypeException ex) {
             return false;
         }
+    }
+
+    private double qualityForJson(List<MediaType> requestedTypes) {
+        MediaType bestMatch = null;
+        int bestSpecificity = -1;
+
+        for (MediaType requestedType : requestedTypes) {
+            if (!requestedType.includes(MediaType.APPLICATION_JSON)
+                && !requestedType.isCompatibleWith(MediaType.APPLICATION_JSON)) {
+                continue;
+            }
+
+            int specificity = specificityForJson(requestedType);
+            if (specificity > bestSpecificity
+                || (specificity == bestSpecificity
+                    && bestMatch != null
+                    && requestedType.getQualityValue() > bestMatch.getQualityValue())) {
+                bestMatch = requestedType;
+                bestSpecificity = specificity;
+            }
+        }
+
+        return bestMatch == null ? 0.0 : bestMatch.getQualityValue();
+    }
+
+    private int specificityForJson(MediaType requestedType) {
+        if (MediaType.APPLICATION_JSON.equalsTypeAndSubtype(requestedType)) {
+            return 2;
+        }
+        if ("application".equals(requestedType.getType()) && requestedType.isWildcardSubtype()) {
+            return 1;
+        }
+        return 0;
     }
 
     private boolean hasRequestBodyMetadata(HttpServletRequest request) {

--- a/backend/src/main/java/com/stephendarcy/personal/web/RuntimeStatusRequestValidationFilter.java
+++ b/backend/src/main/java/com/stephendarcy/personal/web/RuntimeStatusRequestValidationFilter.java
@@ -40,7 +40,7 @@ public class RuntimeStatusRequestValidationFilter extends OncePerRequestFilter {
             return;
         }
 
-        if (!HttpMethod.GET.matches(request.getMethod())) {
+        if (!isGetLikeMethod(request)) {
             filterChain.doFilter(request, response);
             return;
         }
@@ -90,6 +90,10 @@ public class RuntimeStatusRequestValidationFilter extends OncePerRequestFilter {
         String contextPath = request.getContextPath();
         String path = contextPath.isBlank() ? requestPath : requestPath.substring(contextPath.length());
         return "/api/v1/health".equals(path) || "/api/v1/version".equals(path);
+    }
+
+    private boolean isGetLikeMethod(HttpServletRequest request) {
+        return HttpMethod.GET.matches(request.getMethod()) || HttpMethod.HEAD.matches(request.getMethod());
     }
 
     private boolean acceptsJson(HttpServletRequest request) {

--- a/backend/src/main/java/com/stephendarcy/personal/web/RuntimeStatusRequestValidationFilter.java
+++ b/backend/src/main/java/com/stephendarcy/personal/web/RuntimeStatusRequestValidationFilter.java
@@ -1,0 +1,115 @@
+package com.stephendarcy.personal.web;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.InvalidMediaTypeException;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 1)
+public class RuntimeStatusRequestValidationFilter extends OncePerRequestFilter {
+
+    private final ApiErrorWriter errorWriter;
+
+    public RuntimeStatusRequestValidationFilter(ApiErrorWriter errorWriter) {
+        this.errorWriter = errorWriter;
+    }
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+        if (!isRuntimeStatusPath(request) || HttpMethod.OPTIONS.matches(request.getMethod())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (!acceptsJson(request)) {
+            errorWriter.write(
+                request,
+                response,
+                HttpStatus.NOT_ACCEPTABLE,
+                "request.not-acceptable",
+                "Response format not supported",
+                "This endpoint returns application/json responses."
+            );
+            return;
+        }
+
+        if (!HttpMethod.GET.matches(request.getMethod())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (request.getQueryString() != null) {
+            errorWriter.write(
+                request,
+                response,
+                HttpStatus.BAD_REQUEST,
+                "request.validation-failed",
+                "Request validation failed",
+                "This read-only endpoint does not accept query parameters.",
+                List.of(new FieldErrorDetail("query", "Remove query parameters from this request."))
+            );
+            return;
+        }
+
+        if (hasRequestBodyMetadata(request)) {
+            errorWriter.write(
+                request,
+                response,
+                HttpStatus.UNSUPPORTED_MEDIA_TYPE,
+                "request.unsupported-media-type",
+                "Request content type not supported",
+                "This read-only endpoint does not accept a request body."
+            );
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean isRuntimeStatusPath(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return "/api/v1/health".equals(path) || "/api/v1/version".equals(path);
+    }
+
+    private boolean acceptsJson(HttpServletRequest request) {
+        List<String> acceptHeaders = Collections.list(request.getHeaders(HttpHeaders.ACCEPT));
+        if (acceptHeaders.isEmpty()) {
+            return true;
+        }
+
+        try {
+            List<MediaType> requestedTypes = MediaType.parseMediaTypes(acceptHeaders);
+            return requestedTypes.stream().anyMatch((requestedType) ->
+                requestedType.includes(MediaType.ALL) || requestedType.isCompatibleWith(MediaType.APPLICATION_JSON)
+            );
+        }
+        catch (InvalidMediaTypeException ex) {
+            return false;
+        }
+    }
+
+    private boolean hasRequestBodyMetadata(HttpServletRequest request) {
+        return request.getContentLengthLong() > 0
+            || request.getHeader(HttpHeaders.TRANSFER_ENCODING) != null
+            || request.getHeader(HttpHeaders.CONTENT_TYPE) != null;
+    }
+}

--- a/backend/src/main/java/com/stephendarcy/personal/web/RuntimeStatusRequestValidationFilter.java
+++ b/backend/src/main/java/com/stephendarcy/personal/web/RuntimeStatusRequestValidationFilter.java
@@ -40,6 +40,11 @@ public class RuntimeStatusRequestValidationFilter extends OncePerRequestFilter {
             return;
         }
 
+        if (!HttpMethod.GET.matches(request.getMethod())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         if (!acceptsJson(request)) {
             errorWriter.write(
                 request,
@@ -49,11 +54,6 @@ public class RuntimeStatusRequestValidationFilter extends OncePerRequestFilter {
                 "Response format not supported",
                 "This endpoint returns application/json responses."
             );
-            return;
-        }
-
-        if (!HttpMethod.GET.matches(request.getMethod())) {
-            filterChain.doFilter(request, response);
             return;
         }
 
@@ -99,7 +99,9 @@ public class RuntimeStatusRequestValidationFilter extends OncePerRequestFilter {
         try {
             List<MediaType> requestedTypes = MediaType.parseMediaTypes(acceptHeaders);
             return requestedTypes.stream().anyMatch((requestedType) ->
-                requestedType.includes(MediaType.ALL) || requestedType.isCompatibleWith(MediaType.APPLICATION_JSON)
+                requestedType.getQualityValue() > 0.0
+                    && (requestedType.includes(MediaType.APPLICATION_JSON)
+                        || requestedType.isCompatibleWith(MediaType.APPLICATION_JSON))
             );
         }
         catch (InvalidMediaTypeException ex) {

--- a/backend/src/main/java/com/stephendarcy/personal/web/RuntimeStatusRequestValidationFilter.java
+++ b/backend/src/main/java/com/stephendarcy/personal/web/RuntimeStatusRequestValidationFilter.java
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Component
-@Order(Ordered.HIGHEST_PRECEDENCE + 1)
+@Order(Ordered.HIGHEST_PRECEDENCE + 2)
 public class RuntimeStatusRequestValidationFilter extends OncePerRequestFilter {
 
     private final ApiErrorWriter errorWriter;

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,22 @@
+spring:
+  application:
+    name: personal-api
+  mvc:
+    throw-exception-if-no-handler-found: true
+  web:
+    resources:
+      add-mappings: false
+
+server:
+  error:
+    whitelabel:
+      enabled: false
+
+app:
+  runtime:
+    service-name: personal-api
+    version: "0.1.0"
+    build-timestamp: "2026-01-15T10:00:00Z"
+    commit-sha: "0123456789abcdef0123456789abcdef01234567"
+  cors:
+    allowed-origin: "http://localhost:3000"

--- a/backend/src/test/java/com/stephendarcy/personal/runtime/RuntimeStatusApiTests.java
+++ b/backend/src/test/java/com/stephendarcy/personal/runtime/RuntimeStatusApiTests.java
@@ -1,0 +1,147 @@
+package com.stephendarcy.personal.runtime;
+
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.stephendarcy.personal.web.CorrelationIds;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class RuntimeStatusApiTests {
+
+    private static final String CORRELATION_PATTERN = "^[A-Za-z0-9._:-]{8,128}$";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void healthReturnsContractAlignedReadinessResponse() throws Exception {
+        mockMvc.perform(get("/api/v1/health").accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(header().string(CorrelationIds.HEADER, matchesPattern(CORRELATION_PATTERN)))
+            .andExpect(jsonPath("$.status").value("ready"))
+            .andExpect(jsonPath("$.serviceName").value("personal-api"))
+            .andExpect(jsonPath("$.checkedAt").isString());
+    }
+
+    @Test
+    void versionReturnsPublicSafeBuildMetadata() throws Exception {
+        mockMvc.perform(get("/api/v1/version").accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(header().string(CorrelationIds.HEADER, matchesPattern(CORRELATION_PATTERN)))
+            .andExpect(jsonPath("$.serviceName").value("personal-api"))
+            .andExpect(jsonPath("$.version").value("0.1.0"))
+            .andExpect(jsonPath("$.buildTimestamp").value("2026-01-15T10:00:00Z"))
+            .andExpect(jsonPath("$.commitSha").value("0123456789abcdef0123456789abcdef01234567"));
+    }
+
+    @Test
+    void validCorrelationIdIsEchoedInSuccessHeader() throws Exception {
+        String correlationId = "req_20260115_103000_demo";
+
+        mockMvc.perform(get("/api/v1/health").header(CorrelationIds.HEADER, correlationId))
+            .andExpect(status().isOk())
+            .andExpect(header().string(CorrelationIds.HEADER, correlationId));
+    }
+
+    @Test
+    void invalidCorrelationIdReturnsStructuredErrorWithoutEchoingUnsafeInput() throws Exception {
+        mockMvc.perform(get("/api/v1/health").header(CorrelationIds.HEADER, "bad value with spaces"))
+            .andExpect(status().isBadRequest())
+            .andExpect(header().string(CorrelationIds.HEADER, matchesPattern(CORRELATION_PATTERN)))
+            .andExpect(jsonPath("$.type").value("request.invalid-header"))
+            .andExpect(jsonPath("$.title").value("Invalid request header"))
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.detail").value("The supplied correlation identifier is not in an accepted format."))
+            .andExpect(jsonPath("$.instance").value("/api/v1/health"))
+            .andExpect(jsonPath("$.correlationId").value(matchesPattern(CORRELATION_PATTERN)))
+            .andExpect(jsonPath("$.correlationId").value(org.hamcrest.Matchers.not("bad value with spaces")))
+            .andExpect(jsonPath("$.errors[0].field").value(CorrelationIds.HEADER));
+    }
+
+    @Test
+    void unsupportedMethodReturnsStructuredError() throws Exception {
+        mockMvc.perform(post("/api/v1/health").accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isMethodNotAllowed())
+            .andExpect(header().string(CorrelationIds.HEADER, matchesPattern(CORRELATION_PATTERN)))
+            .andExpect(jsonPath("$.type").value("request.method-not-allowed"))
+            .andExpect(jsonPath("$.status").value(405))
+            .andExpect(jsonPath("$.instance").value("/api/v1/health"));
+    }
+
+    @Test
+    void unsupportedResponseFormatReturnsStructuredError() throws Exception {
+        mockMvc.perform(get("/api/v1/version").accept(MediaType.APPLICATION_XML))
+            .andExpect(status().isNotAcceptable())
+            .andExpect(header().string(CorrelationIds.HEADER, matchesPattern(CORRELATION_PATTERN)))
+            .andExpect(jsonPath("$.type").value("request.not-acceptable"))
+            .andExpect(jsonPath("$.status").value(406))
+            .andExpect(jsonPath("$.instance").value("/api/v1/version"));
+    }
+
+    @Test
+    void unexpectedContentTypeReturnsStructuredUnsupportedMediaTypeError() throws Exception {
+        mockMvc.perform(get("/api/v1/health").contentType(MediaType.TEXT_PLAIN))
+            .andExpect(status().isUnsupportedMediaType())
+            .andExpect(header().string(CorrelationIds.HEADER, matchesPattern(CORRELATION_PATTERN)))
+            .andExpect(jsonPath("$.type").value("request.unsupported-media-type"))
+            .andExpect(jsonPath("$.status").value(415))
+            .andExpect(jsonPath("$.instance").value("/api/v1/health"));
+    }
+
+    @Test
+    void unexpectedBodyReturnsStructuredUnsupportedMediaTypeError() throws Exception {
+        mockMvc.perform(get("/api/v1/health")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"unexpected\":true}"))
+            .andExpect(status().isUnsupportedMediaType())
+            .andExpect(header().string(CorrelationIds.HEADER, matchesPattern(CORRELATION_PATTERN)))
+            .andExpect(jsonPath("$.type").value("request.unsupported-media-type"))
+            .andExpect(jsonPath("$.detail").value("This read-only endpoint does not accept a request body."));
+    }
+
+    @Test
+    void queryParametersReturnStructuredValidationError() throws Exception {
+        mockMvc.perform(get("/api/v1/health?detail=true"))
+            .andExpect(status().isBadRequest())
+            .andExpect(header().string(CorrelationIds.HEADER, matchesPattern(CORRELATION_PATTERN)))
+            .andExpect(jsonPath("$.type").value("request.validation-failed"))
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.errors[0].field").value("query"));
+    }
+
+    @Test
+    void unmappedRouteReturnsStructuredNotFoundError() throws Exception {
+        mockMvc.perform(get("/api/v1/example").accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(header().string(CorrelationIds.HEADER, matchesPattern(CORRELATION_PATTERN)))
+            .andExpect(jsonPath("$.type").value("request.not-found"))
+            .andExpect(jsonPath("$.status").value(404))
+            .andExpect(jsonPath("$.instance").value("/api/v1/example"));
+    }
+
+    @Test
+    void allowedFrontendOriginReceivesCorsResponseHeaders() throws Exception {
+        mockMvc.perform(options("/api/v1/health")
+                .header(HttpHeaders.ORIGIN, "http://localhost:3000")
+                .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET")
+                .header(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS, CorrelationIds.HEADER))
+            .andExpect(status().isOk())
+            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://localhost:3000"))
+            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, org.hamcrest.Matchers.containsString("GET")))
+            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, org.hamcrest.Matchers.containsString(CorrelationIds.HEADER)));
+    }
+}

--- a/backend/src/test/java/com/stephendarcy/personal/runtime/RuntimeStatusApiTests.java
+++ b/backend/src/test/java/com/stephendarcy/personal/runtime/RuntimeStatusApiTests.java
@@ -76,6 +76,7 @@ class RuntimeStatusApiTests {
     void unsupportedMethodReturnsStructuredError() throws Exception {
         mockMvc.perform(post("/api/v1/health").accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isMethodNotAllowed())
+            .andExpect(header().string(HttpHeaders.ALLOW, org.hamcrest.Matchers.containsString("GET")))
             .andExpect(header().string(CorrelationIds.HEADER, matchesPattern(CORRELATION_PATTERN)))
             .andExpect(jsonPath("$.type").value("request.method-not-allowed"))
             .andExpect(jsonPath("$.status").value(405))

--- a/backend/src/test/java/com/stephendarcy/personal/runtime/RuntimeStatusApiTests.java
+++ b/backend/src/test/java/com/stephendarcy/personal/runtime/RuntimeStatusApiTests.java
@@ -84,6 +84,15 @@ class RuntimeStatusApiTests {
     }
 
     @Test
+    void unsupportedMethodReturnsMethodErrorBeforeAcceptNegotiation() throws Exception {
+        mockMvc.perform(post("/api/v1/health").accept(MediaType.TEXT_PLAIN))
+            .andExpect(status().isMethodNotAllowed())
+            .andExpect(header().string(HttpHeaders.ALLOW, org.hamcrest.Matchers.containsString("GET")))
+            .andExpect(jsonPath("$.type").value("request.method-not-allowed"))
+            .andExpect(jsonPath("$.status").value(405));
+    }
+
+    @Test
     void unsupportedResponseFormatReturnsStructuredError() throws Exception {
         mockMvc.perform(get("/api/v1/version").accept(MediaType.APPLICATION_XML))
             .andExpect(status().isNotAcceptable())
@@ -91,6 +100,15 @@ class RuntimeStatusApiTests {
             .andExpect(jsonPath("$.type").value("request.not-acceptable"))
             .andExpect(jsonPath("$.status").value(406))
             .andExpect(jsonPath("$.instance").value("/api/v1/version"));
+    }
+
+    @Test
+    void jsonWithZeroQualityReturnsStructuredNotAcceptableError() throws Exception {
+        mockMvc.perform(get("/api/v1/version").header(HttpHeaders.ACCEPT, "application/json;q=0"))
+            .andExpect(status().isNotAcceptable())
+            .andExpect(header().string(CorrelationIds.HEADER, matchesPattern(CORRELATION_PATTERN)))
+            .andExpect(jsonPath("$.type").value("request.not-acceptable"))
+            .andExpect(jsonPath("$.status").value(406));
     }
 
     @Test

--- a/backend/src/test/java/com/stephendarcy/personal/runtime/RuntimeStatusApiTests.java
+++ b/backend/src/test/java/com/stephendarcy/personal/runtime/RuntimeStatusApiTests.java
@@ -112,6 +112,15 @@ class RuntimeStatusApiTests {
     }
 
     @Test
+    void explicitJsonExclusionWinsOverWildcardAcceptHeader() throws Exception {
+        mockMvc.perform(get("/api/v1/version").header(HttpHeaders.ACCEPT, "application/json;q=0, */*;q=0.8"))
+            .andExpect(status().isNotAcceptable())
+            .andExpect(header().string(CorrelationIds.HEADER, matchesPattern(CORRELATION_PATTERN)))
+            .andExpect(jsonPath("$.type").value("request.not-acceptable"))
+            .andExpect(jsonPath("$.status").value(406));
+    }
+
+    @Test
     void unexpectedContentTypeReturnsStructuredUnsupportedMediaTypeError() throws Exception {
         mockMvc.perform(get("/api/v1/health").contentType(MediaType.TEXT_PLAIN))
             .andExpect(status().isUnsupportedMediaType())
@@ -140,6 +149,15 @@ class RuntimeStatusApiTests {
             .andExpect(jsonPath("$.type").value("request.validation-failed"))
             .andExpect(jsonPath("$.status").value(400))
             .andExpect(jsonPath("$.errors[0].field").value("query"));
+    }
+
+    @Test
+    void runtimeRouteValidationAppliesWithServletContextPath() throws Exception {
+        mockMvc.perform(get("/personal/api/v1/health?detail=true").contextPath("/personal"))
+            .andExpect(status().isBadRequest())
+            .andExpect(header().string(CorrelationIds.HEADER, matchesPattern(CORRELATION_PATTERN)))
+            .andExpect(jsonPath("$.type").value("request.validation-failed"))
+            .andExpect(jsonPath("$.instance").value("/personal/api/v1/health"));
     }
 
     @Test

--- a/backend/src/test/java/com/stephendarcy/personal/runtime/RuntimeStatusApiTests.java
+++ b/backend/src/test/java/com/stephendarcy/personal/runtime/RuntimeStatusApiTests.java
@@ -152,6 +152,15 @@ class RuntimeStatusApiTests {
     }
 
     @Test
+    void filterGeneratedErrorsPreserveCorsHeadersForAllowedFrontendOrigin() throws Exception {
+        mockMvc.perform(get("/api/v1/health?detail=true").header(HttpHeaders.ORIGIN, "http://localhost:3000"))
+            .andExpect(status().isBadRequest())
+            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://localhost:3000"))
+            .andExpect(header().string(HttpHeaders.VARY, org.hamcrest.Matchers.containsString("Origin")))
+            .andExpect(jsonPath("$.type").value("request.validation-failed"));
+    }
+
+    @Test
     void runtimeRouteValidationAppliesWithServletContextPath() throws Exception {
         mockMvc.perform(get("/personal/api/v1/health?detail=true").contextPath("/personal"))
             .andExpect(status().isBadRequest())

--- a/backend/src/test/java/com/stephendarcy/personal/runtime/RuntimeStatusApiTests.java
+++ b/backend/src/test/java/com/stephendarcy/personal/runtime/RuntimeStatusApiTests.java
@@ -198,4 +198,14 @@ class RuntimeStatusApiTests {
             .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, org.hamcrest.Matchers.containsString("GET")))
             .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, org.hamcrest.Matchers.containsString(CorrelationIds.HEADER)));
     }
+
+    @Test
+    void allowedFrontendOriginCanPreflightHeadRuntimeRequest() throws Exception {
+        mockMvc.perform(options("/api/v1/health")
+                .header(HttpHeaders.ORIGIN, "http://localhost:3000")
+                .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "HEAD"))
+            .andExpect(status().isOk())
+            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://localhost:3000"))
+            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, org.hamcrest.Matchers.containsString("HEAD")));
+    }
 }

--- a/backend/src/test/java/com/stephendarcy/personal/runtime/RuntimeStatusApiTests.java
+++ b/backend/src/test/java/com/stephendarcy/personal/runtime/RuntimeStatusApiTests.java
@@ -2,6 +2,7 @@ package com.stephendarcy.personal.runtime;
 
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.head;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -149,6 +150,13 @@ class RuntimeStatusApiTests {
             .andExpect(jsonPath("$.type").value("request.validation-failed"))
             .andExpect(jsonPath("$.status").value(400))
             .andExpect(jsonPath("$.errors[0].field").value("query"));
+    }
+
+    @Test
+    void headRequestsUseRuntimeRouteValidation() throws Exception {
+        mockMvc.perform(head("/api/v1/health?detail=true"))
+            .andExpect(status().isBadRequest())
+            .andExpect(header().string(CorrelationIds.HEADER, matchesPattern(CORRELATION_PATTERN)));
     }
 
     @Test

--- a/backend/src/test/java/com/stephendarcy/personal/web/ApiExceptionHandlerTests.java
+++ b/backend/src/test/java/com/stephendarcy/personal/web/ApiExceptionHandlerTests.java
@@ -1,0 +1,35 @@
+package com.stephendarcy.personal.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+@ExtendWith(OutputCaptureExtension.class)
+class ApiExceptionHandlerTests {
+
+    private final ApiExceptionHandler handler = new ApiExceptionHandler(new ApiErrorFactory());
+
+    @Test
+    void unexpectedExceptionsAreLoggedBeforeSanitizedResponseIsReturned(CapturedOutput output) {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/version");
+        request.setAttribute(CorrelationIds.ATTRIBUTE, "req_20260115_103000_demo");
+
+        ResponseEntity<ApiErrorResponse> response = handler.handleUnexpected(
+            new IllegalStateException("example failure"),
+            request
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().detail()).isEqualTo("The server could not complete the request.");
+        assertThat(output).contains("Unexpected API request failure");
+        assertThat(output).contains("req_20260115_103000_demo");
+        assertThat(output).contains("/api/v1/version");
+    }
+}

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -4,7 +4,7 @@ This document tracks the expected local development shape as runtime components 
 
 ## Current State
 
-The repository has a runnable frontend scaffold and an initial OpenAPI source contract. Backend scaffolding is still planned follow-up work.
+The repository has a runnable frontend scaffold, an initial OpenAPI source contract, and the first Spring Boot runtime status API slice.
 
 ## Planned Commands
 
@@ -30,6 +30,13 @@ Contract command:
 
 ```powershell
 node scripts/contracts/check-openapi.mjs
+```
+
+Backend command:
+
+```powershell
+cd backend
+mvn --batch-mode verify
 ```
 
 ## Security Rules


### PR DESCRIPTION
## Summary

- Add the first Java 21 Spring Boot 3.5.x backend scaffold for the public runtime status API.
- Implement `GET /api/v1/health` and `GET /api/v1/version` with contract-aligned response shapes.
- Add structured public-safe error handling, request correlation, narrow CORS configuration, and focused MockMvc coverage.
- Document local Maven verification, local run, and Spring Boot buildpack image commands.

## Scope

This stays within Issue #12 and ADR 0009. It does not add persistence, authentication, contact workflows, analytics collection, product data, frontend API consumption, or deployment infrastructure beyond the local buildpack image path.

Closes #12.

## Verification

- `node scripts/contracts/check-openapi.mjs`
- `mvn --batch-mode verify` from `backend/`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/security/preflight.ps1 -Scope Repository -RequireGitleaks`

Frontend lint, typecheck, and build were skipped because this PR does not change frontend files. The repository security preflight still ran the existing frontend npm audit and reported zero vulnerabilities.