### PR TITLE
[codex] Add backend CI and container verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,42 @@ jobs:
           npm test --if-present
           npm run build --if-present
 
-      - name: Set up Java when backend exists
-        if: ${{ hashFiles('backend/pom.xml') != '' }}
+  backend-verification:
+    name: backend-verification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect backend changes
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+          else
+            base="${{ github.event.before }}"
+            head="${{ github.sha }}"
+            if [ "$base" = "0000000000000000000000000000000000000000" ]; then
+              base="$(git rev-list --max-parents=0 "$head")"
+            fi
+          fi
+
+          changed_files="$(git diff --name-only "$base" "$head")"
+          printf '%s\n' "$changed_files"
+          if printf '%s\n' "$changed_files" | grep -Eq '^(backend/|scripts/backend/|\.github/workflows/ci\.yml$)'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Java
+        if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
@@ -98,7 +132,7 @@ jobs:
           cache: maven
 
       - name: Backend checks
-        if: ${{ hashFiles('backend/pom.xml') != '' }}
+        if: steps.changes.outputs.changed == 'true'
         working-directory: backend
         shell: bash
         run: |
@@ -108,3 +142,90 @@ jobs:
           else
             mvn --batch-mode verify
           fi
+
+      - name: Skip backend checks
+        if: steps.changes.outputs.changed != 'true'
+        run: echo "No backend-affecting files changed; skipping backend Maven verification."
+
+  backend-container:
+    name: backend-container
+    runs-on: ubuntu-latest
+    needs: backend-verification
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect backend changes
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+          else
+            base="${{ github.event.before }}"
+            head="${{ github.sha }}"
+            if [ "$base" = "0000000000000000000000000000000000000000" ]; then
+              base="$(git rev-list --max-parents=0 "$head")"
+            fi
+          fi
+
+          changed_files="$(git diff --name-only "$base" "$head")"
+          printf '%s\n' "$changed_files"
+          if printf '%s\n' "$changed_files" | grep -Eq '^(backend/|scripts/backend/|\.github/workflows/ci\.yml$)'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Java
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+
+      - name: Build backend image
+        if: steps.changes.outputs.changed == 'true'
+        working-directory: backend
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -x ./mvnw ]; then
+            ./mvnw --batch-mode -DskipTests spring-boot:build-image -Dspring-boot.build-image.imageName=personal-api:ci
+          else
+            mvn --batch-mode -DskipTests spring-boot:build-image -Dspring-boot.build-image.imageName=personal-api:ci
+          fi
+
+      - name: Install Trivy
+        if: steps.changes.outputs.changed == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="0.70.0"
+          expected_sha256="8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9"
+          curl -sSL \
+            "https://github.com/aquasecurity/trivy/releases/download/v${version}/trivy_${version}_Linux-64bit.tar.gz" \
+            -o trivy.tar.gz
+          echo "${expected_sha256}  trivy.tar.gz" | sha256sum --check --strict
+          tar -xzf trivy.tar.gz trivy
+          ./trivy --version
+
+      - name: Scan backend image
+        if: steps.changes.outputs.changed == 'true'
+        shell: bash
+        run: ./trivy image --no-progress --severity HIGH,CRITICAL --exit-code 1 personal-api:ci
+
+      - name: Smoke test backend image
+        if: steps.changes.outputs.changed == 'true'
+        shell: pwsh
+        run: ./scripts/backend/smoke-container.ps1 -ImageName personal-api:ci -HostPort 18080 -SkipBuild
+
+      - name: Skip backend container checks
+        if: steps.changes.outputs.changed != 'true'
+        run: echo "No backend-affecting files changed; skipping backend container scan and smoke checks."

--- a/backend/README.md
+++ b/backend/README.md
@@ -7,7 +7,7 @@ This directory contains the public Spring Boot API.
 - Framework: Spring Boot 3.5.x.
 - Runtime: Java 21.
 - Build: Maven.
-- Packaging: executable Spring Boot jar. Container packaging should be added with the matching container scan gate before a Dockerfile is introduced.
+- Packaging: executable Spring Boot jar and Spring Boot buildpack image.
 
 ## Boundaries
 
@@ -54,7 +54,7 @@ cd backend
 mvn --batch-mode spring-boot:build-image -Dspring-boot.build-image.imageName=personal-api:local
 ```
 
-The image command requires a local Docker-compatible runtime. Do not add a Dockerfile until container scanning is wired into the repository security gates.
+The image command requires a local Docker-compatible runtime.
 
 Example local checks:
 
@@ -62,3 +62,11 @@ Example local checks:
 Invoke-RestMethod -Uri "http://localhost:8080/api/v1/health" -Headers @{ "X-Correlation-ID" = "req_20260115_103000_demo" }
 Invoke-RestMethod -Uri "http://localhost:8080/api/v1/version"
 ```
+
+Build and smoke-test the backend container from the repository root:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts/backend/smoke-container.ps1 -ImageName personal-api:local
+```
+
+CI builds the same buildpack image, scans it with Trivy, and exercises `/api/v1/health` and `/api/v1/version` from the running container. Keep Dockerfile-based packaging out of this repository unless the workflow security gates are updated for that path.

--- a/docs/github-admin-checklist.md
+++ b/docs/github-admin-checklist.md
@@ -46,6 +46,11 @@ Private-repo strict substitutes that should be required now:
 
 Update the required check list as app-specific CI jobs are added.
 
+Backend status checks to require after Issue #13 lands:
+
+- `backend-verification`
+- `backend-container`
+
 After the repository is public, apply the baseline protection from a local admin checkout:
 
 ```powershell

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -6,9 +6,9 @@ This document tracks the expected local development shape as runtime components 
 
 The repository has a runnable frontend scaffold, an initial OpenAPI source contract, and the first Spring Boot runtime status API slice.
 
-## Planned Commands
+## Local Commands
 
-Once the runtime scaffolds exist, local development should provide checked-in commands for:
+Local development provides checked-in commands for:
 
 - Frontend install, lint, typecheck, and build.
 - Backend verify, test, and package.
@@ -39,6 +39,16 @@ cd backend
 mvn --batch-mode verify
 ```
 
+Backend container smoke command:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts/backend/smoke-container.ps1 -ImageName personal-api:local
+```
+
+The smoke command builds the Spring Boot buildpack image, starts it on `localhost:18080`, checks `/api/v1/health` and `/api/v1/version`, and removes the container when it finishes. It requires Docker or a Docker-compatible local runtime.
+
+CI runs backend Maven verification and backend container verification for backend-affecting changes. The container job builds the buildpack image, scans it with Trivy, and runs the same smoke script against the already-built image.
+
 ## Security Rules
 
 - Keep local secrets in ignored environment files or managed secret stores.
@@ -61,5 +71,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File scripts/security/preflight.p
 ```
 
 The preflight checks tracked or staged files for sensitive paths, common secret patterns, non-example email addresses, personal identifier fields, local tooling files that should stay untracked, placeholder copy, and public-tone drift. When `gitleaks` is installed, it also runs a dedicated secret scan. The pre-push hook requires `gitleaks` so pushes do not rely only on the built-in pattern checks.
+
+The repository preflight also runs the frontend npm audit when `frontend/package-lock.json` exists. That audit is part of the repository-level security check even when frontend source files are otherwise untouched.
 
 See [docs/content-standards.md](content-standards.md) for the public content rules enforced by the local preflight.

--- a/scripts/backend/smoke-container.ps1
+++ b/scripts/backend/smoke-container.ps1
@@ -1,0 +1,141 @@
+[CmdletBinding()]
+param(
+    [string]$ImageName = "personal-api:local",
+    [ValidateRange(1024, 65535)]
+    [int]$HostPort = 18080,
+    [string]$ContainerName = "",
+    [switch]$SkipBuild
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Write-Section {
+    param([string]$Message)
+    Write-Host ""
+    Write-Host "==> $Message"
+}
+
+function Get-RepoRoot {
+    $root = (& git rev-parse --show-toplevel 2>$null)
+    if (-not $root) {
+        throw "This script must be run inside the repository."
+    }
+    return (Resolve-Path -LiteralPath $root).Path
+}
+
+function Assert-DockerAvailable {
+    if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+        throw "Docker or a Docker-compatible CLI is required for backend container smoke checks."
+    }
+    & docker info *> $null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Docker is installed but is not available. Start the Docker-compatible runtime and try again."
+    }
+}
+
+function Invoke-SmokeRequest {
+    param(
+        [string]$Path,
+        [scriptblock]$Validate
+    )
+
+    $uri = "http://localhost:${HostPort}${Path}"
+    $headers = @{
+        Accept = "application/json"
+        "X-Correlation-ID" = "req_20260115_103000_demo"
+    }
+    $response = Invoke-WebRequest -UseBasicParsing -Uri $uri -Headers $headers
+    if ($response.StatusCode -ne 200) {
+        throw "${Path} returned HTTP $($response.StatusCode)."
+    }
+    $body = $response.Content | ConvertFrom-Json
+    & $Validate $body
+    Write-Host "${Path} passed."
+}
+
+$repoRoot = Get-RepoRoot
+if ([string]::IsNullOrWhiteSpace($ContainerName)) {
+    $ContainerName = "personal-api-smoke-$PID"
+}
+
+Assert-DockerAvailable
+
+if (-not $SkipBuild) {
+    Write-Section "Building backend image"
+    Push-Location (Join-Path $repoRoot "backend")
+    try {
+        & mvn --batch-mode spring-boot:build-image "-Dspring-boot.build-image.imageName=$ImageName"
+        if ($LASTEXITCODE -ne 0) {
+            throw "Backend image build failed."
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+Write-Section "Starting backend container"
+& docker rm -f $ContainerName *> $null
+& docker run --rm --detach --name $ContainerName --publish "$($HostPort):8080" $ImageName
+if ($LASTEXITCODE -ne 0) {
+    throw "Backend container failed to start."
+}
+
+try {
+    Write-Section "Waiting for runtime status API"
+    $ready = $false
+    for ($attempt = 1; $attempt -le 30; $attempt++) {
+        try {
+            $health = Invoke-WebRequest -UseBasicParsing -Uri "http://localhost:${HostPort}/api/v1/health" -Headers @{ Accept = "application/json" }
+            if ($health.StatusCode -eq 200) {
+                $ready = $true
+                break
+            }
+        }
+        catch {
+            Start-Sleep -Seconds 2
+        }
+    }
+
+    if (-not $ready) {
+        & docker logs $ContainerName
+        throw "Backend container did not become ready."
+    }
+
+    Write-Section "Checking runtime status endpoints"
+    Invoke-SmokeRequest -Path "/api/v1/health" -Validate {
+        param($Body)
+        if ($Body.status -ne "ready") {
+            throw "Health response did not report ready."
+        }
+        if ($Body.serviceName -ne "personal-api") {
+            throw "Health response used an unexpected serviceName."
+        }
+        if (-not $Body.checkedAt) {
+            throw "Health response did not include checkedAt."
+        }
+    }
+
+    Invoke-SmokeRequest -Path "/api/v1/version" -Validate {
+        param($Body)
+        if ($Body.serviceName -ne "personal-api") {
+            throw "Version response used an unexpected serviceName."
+        }
+        if ($Body.version -notmatch '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)') {
+            throw "Version response did not include a semantic version."
+        }
+        if ($Body.commitSha -notmatch '^[a-f0-9]{40}$') {
+            throw "Version response did not include a public-safe full commit SHA."
+        }
+        if (-not $Body.buildTimestamp) {
+            throw "Version response did not include buildTimestamp."
+        }
+    }
+
+    Write-Section "Backend container smoke check passed"
+}
+finally {
+    Write-Section "Stopping backend container"
+    & docker rm -f $ContainerName *> $null
+}


### PR DESCRIPTION
## Summary

- Add backend-specific CI checks that run Maven verification for backend-affecting changes.
- Add a buildpack container verification job that builds the backend image, installs Trivy with a pinned checksum, scans the image, and smoke-tests `/api/v1/health` and `/api/v1/version`.
- Add a local PowerShell container smoke script and document the backend verification commands.

## Scope

This stays within Issue #13. It does not add deployment infrastructure, cloud credentials, cloud account configuration, Kubernetes, frontend API consumption, persistence, authentication, analytics collection, contact workflows, or new backend product endpoints.

Closes #13.

## Verification

- `node scripts/contracts/check-openapi.mjs`
- `mvn --batch-mode verify` from `backend/`
- `actionlint .github/workflows/ci.yml .github/workflows/security.yml .github/workflows/repository-setup.yml`
- `powershell -NoProfile -ExecutionPolicy Bypass -Command '$null = [scriptblock]::Create((Get-Content -LiteralPath ''scripts/backend/smoke-container.ps1'' -Raw)); ''PowerShell parse passed.'' '`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/security/preflight.ps1 -Scope Repository -RequireGitleaks`

Local container smoke was attempted with `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/backend/smoke-container.ps1 -ImageName personal-api:local`, but Docker is not installed in this local environment. The new `backend-container` CI job is expected to exercise the Docker-backed build, scan, and smoke path.

Frontend lint, typecheck, and build were skipped locally because this PR does not change frontend source files. The repository security preflight still ran the existing frontend npm audit and reported zero vulnerabilities.