### PR TITLE
[codex] Plan generated frontend client integration

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -13,6 +13,7 @@ This directory contains the public Spring Boot API.
 
 - Keep the backend as the system of record for server-side behavior.
 - Publish OpenAPI documentation for public endpoints.
+- Keep implemented behavior, structured errors, correlation behavior, and OpenAPI contract changes aligned in the same API slice.
 - Add explicit validation, structured errors, request correlation, and narrow CORS rules with the first API slice.
 - Do not store durable visitor-submitted data or add private authenticated areas without an ADR and threat-model update.
 - Keep sample configuration obviously fake and free of real secrets, credentials, and account IDs.
@@ -30,6 +31,8 @@ The first backend slice implements the public runtime status boundary from [ADR 
 Both endpoints are read-only and accept no request body, query parameters, or path parameters.
 
 Do not add product data, persistence, authentication, contact workflows, analytics collection, or other visitor-submitted data in this slice.
+
+Frontend TypeScript clients for these endpoints should be generated from `contracts/runtime-status.openapi.json` under `frontend/src/api/generated/runtime-status/` once the generated-client scripts are implemented. A backend API change is incomplete until backend behavior, the source contract, generated frontend output, and drift checks agree.
 
 ## Local Verification
 

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -7,12 +7,13 @@ This directory contains API contracts and generated-client rules.
 - OpenAPI is the boundary between the frontend and backend.
 - Backend behavior must match the published contract.
 - Frontend API clients should be generated from the contract rather than handwritten.
+- Generated frontend client output belongs to the frontend package under `frontend/src/api/generated/`.
 
 ## Boundaries
 
 - Contract examples must use obviously fake values.
 - Contract changes should be reviewed with both frontend and backend impact in mind.
-- CI should eventually fail when generated clients or published API output drift from the source contract.
+- Generated clients should be committed and checked for drift against the source contract in CI.
 
 ## Source Contracts
 
@@ -40,4 +41,19 @@ Run the dependency-free contract check from the repository root:
 node scripts/contracts/check-openapi.mjs
 ```
 
-Generated-client conventions and drift checks should be added once frontend client generation exists.
+## Generated Frontend Client Plan
+
+ADR 0010 defines the generated frontend client workflow. The planned runtime status output location is:
+
+```text
+frontend/src/api/generated/runtime-status/
+```
+
+Generated output should be committed as reviewable public source. The follow-up implementation should add pinned frontend generator dependencies and expose:
+
+```powershell
+npm --prefix frontend run contracts:generate
+npm --prefix frontend run contracts:check
+```
+
+`contracts:generate` should regenerate the committed TypeScript client from `contracts/runtime-status.openapi.json`. `contracts:check` should regenerate into a temporary location and fail when the committed output differs from the source contract.

--- a/docs/adr/0010-generated-frontend-client-integration.md
+++ b/docs/adr/0010-generated-frontend-client-integration.md
@@ -1,0 +1,51 @@
+# ADR 0010: Generated Frontend Client Integration
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0005 makes OpenAPI the integration boundary between the frontend and backend. The runtime status contract and backend implementation now exist, but the frontend should not handwrite response shapes or start runtime API consumption before the generated-client workflow is clear.
+
+The frontend remains a static-export-first Next.js application. Any backend call from the frontend must be deliberate, public-safe, and compatible with client-side execution unless a later ADR approves server-side frontend behavior.
+
+## Decision
+
+Generated TypeScript API clients will live inside the frontend package under `frontend/src/api/generated/`. Each contract gets its own generated subdirectory; the runtime status client should use `frontend/src/api/generated/runtime-status/`.
+
+Generated output will be committed to the repository as reviewable public source. CI should not silently regenerate clients and continue. Instead, CI should run a drift check that regenerates the client into a temporary location and fails if the committed generated output differs from the OpenAPI source contract.
+
+The first generated runtime status client should be based on the checked-in OpenAPI source contract at `contracts/runtime-status.openapi.json`. The follow-up implementation should pin generator dependencies in `frontend/package.json` and expose these commands:
+
+```powershell
+npm --prefix frontend run contracts:generate
+npm --prefix frontend run contracts:check
+```
+
+`contracts:generate` should regenerate the committed TypeScript client from `contracts/runtime-status.openapi.json`. `contracts:check` should run the same generation into a temporary directory and compare it with `frontend/src/api/generated/runtime-status/` without modifying the working tree.
+
+Repository validation should keep running the existing OpenAPI contract check:
+
+```powershell
+node scripts/contracts/check-openapi.mjs
+```
+
+Once generated-client drift detection exists, CI should run the drift check for pull requests that change `contracts/`, `frontend/src/api/generated/`, the frontend package manifest or lockfile, or the contract-generation scripts.
+
+Frontend and backend ownership for API changes is:
+
+- Backend owns implemented API behavior, validation, structured errors, correlation behavior, and published OpenAPI accuracy.
+- Contract changes are reviewed as the shared boundary and must stay public-safe, with obviously fake examples.
+- Frontend owns committed generated TypeScript output and any handwritten adapter code that wraps the generated client for application use.
+- A backend API change is incomplete until the source contract, backend behavior, generated frontend client, and drift check all agree.
+- A frontend API consumption change must import generated types or generated client entry points instead of duplicating response shapes by hand.
+
+The first safe frontend consumption point for the runtime status API is a future client-side integration point that reads `GET /api/v1/health` and `GET /api/v1/version` after hydration for operational evidence. It should not block the primary static page render, change public content, or introduce persistence, authentication, analytics collection, contact workflows, cloud credentials, or deployment infrastructure.
+
+## Consequences
+
+- API drift becomes visible in pull requests before frontend runtime calls are added.
+- Generated output is reviewable and reproducible.
+- Static export remains the frontend default while runtime API calls are introduced deliberately.
+- The next implementation issue can add generator dependencies, scripts, committed generated output, and CI drift checks without also changing public visual design or wiring live frontend API behavior.

--- a/docs/implementation-roadmap.md
+++ b/docs/implementation-roadmap.md
@@ -122,12 +122,12 @@ Exit criteria:
 
 ## Phase 5: Contract Integration
 
-Connect the frontend to the backend through generated API contracts.
+Connect the frontend to the backend through generated API contracts. ADR 0010 defines the planned generated-client location, committed-output policy, and drift-check workflow.
 
 Exit criteria:
 
 - The OpenAPI contract is the source of truth.
-- Frontend clients are generated or checked from the contract.
+- Frontend clients are generated and checked from the contract.
 - CI fails when generated client output is stale.
 - Contract examples contain only public-safe fake values.
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -12,7 +12,8 @@ Local development provides checked-in commands for:
 
 - Frontend install, lint, typecheck, and build.
 - Backend verify, test, and package.
-- Contract checks and generated-client drift checks.
+- The current OpenAPI contract check.
+- Planned generated-client generation and drift checks.
 - Container build and local runtime smoke checks.
 
 Frontend commands:
@@ -31,6 +32,15 @@ Contract command:
 ```powershell
 node scripts/contracts/check-openapi.mjs
 ```
+
+Planned generated frontend client commands from ADR 0010:
+
+```powershell
+npm --prefix frontend run contracts:generate
+npm --prefix frontend run contracts:check
+```
+
+These commands should regenerate the runtime status TypeScript client from `contracts/runtime-status.openapi.json` and check committed output under `frontend/src/api/generated/runtime-status/` for drift. They are intentionally not wired until the generator dependencies and drift script are added in the follow-up implementation issue.
 
 Backend command:
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -13,8 +13,24 @@ This directory contains the public Next.js application.
 
 - Do not add server-only frontend behavior unless an ADR approves the runtime change.
 - Consume backend APIs through generated clients from `contracts/`.
+- Keep generated clients under `src/api/generated/` and do not handwrite backend response shapes.
 - Keep public examples and fixtures free of secrets, credentials, and real account IDs.
 - Use visual verification evidence for meaningful UI changes once the application exists.
+
+## Generated API Clients
+
+ADR 0010 places generated TypeScript clients in `src/api/generated/`. The runtime status client should be generated into `src/api/generated/runtime-status/` from `../contracts/runtime-status.openapi.json`.
+
+Generated output should be committed. Drift checks should regenerate the client into a temporary location and compare it with the committed output instead of silently updating files in CI.
+
+Planned commands for the follow-up implementation:
+
+```powershell
+npm run contracts:generate
+npm run contracts:check
+```
+
+The first safe runtime status consumption point is a future client-side operational evidence integration that reads `/api/v1/health` and `/api/v1/version` after hydration. Do not wire live backend calls into the public app until a follow-up issue explicitly expands the scope.
 
 ## Next Implementation Step
 


### PR DESCRIPTION
## Summary

- Add ADR 0010 for generated frontend client integration.
- Document the generated TypeScript client location, committed-output policy, and drift-check workflow.
- Clarify frontend/backend API ownership boundaries and the first safe runtime status consumption point.

## Scope

This stays within Issue #14. It does not build frontend runtime API consumption, add backend endpoints, change public content or visual design, add persistence, authentication, contact workflows, analytics collection, deployment infrastructure, cloud credentials, or cloud account configuration.

Closes #14.

## Verification

- `git diff --check`
- `node scripts/contracts/check-openapi.mjs`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/security/preflight.ps1 -Scope Repository -RequireGitleaks`

The repository preflight ran the frontend npm audit internally and reported zero vulnerabilities.

Workflow/security validation was skipped because `.github/workflows` files were not changed.

Frontend lint/typecheck/build and backend Maven verification were skipped because frontend and backend implementation or build configuration files were not changed.