### PR TITLE
[codex] Add generated client drift CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,61 @@ jobs:
           npm test --if-present
           npm run build --if-present
 
+  generated-client-drift:
+    name: generated-client-drift
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect generated-client drift check changes
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+          else
+            base="${{ github.event.before }}"
+            head="${{ github.sha }}"
+            if [ "$base" = "0000000000000000000000000000000000000000" ]; then
+              base="$(git rev-list --max-parents=0 "$head")"
+            fi
+          fi
+
+          changed_files="$(git diff --name-only "$base" "$head")"
+          printf '%s\n' "$changed_files"
+          if printf '%s\n' "$changed_files" | grep -Eq '^(contracts/|frontend/src/api/generated/|frontend/package(-lock)?\.json$|frontend/scripts/(check-runtime-status-client-drift|generate-runtime-status-client|runtime-status-client-generator)\.mjs$|\.github/workflows/ci\.yml$)'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Node
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Check generated runtime status client drift
+        if: steps.changes.outputs.changed == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm ci --prefix frontend
+          node scripts/contracts/check-openapi.mjs
+          npm --prefix frontend run contracts:check
+
+      - name: Skip generated-client drift check
+        if: steps.changes.outputs.changed != 'true'
+        run: echo "No generated-client-affecting files changed; skipping generated-client drift check."
+
   backend-verification:
     name: backend-verification
     runs-on: ubuntu-latest

--- a/docs/github-admin-checklist.md
+++ b/docs/github-admin-checklist.md
@@ -51,6 +51,10 @@ Backend status checks to require after Issue #13 lands:
 - `backend-verification`
 - `backend-container`
 
+Generated-client status checks to require after Issue #20 lands:
+
+- `generated-client-drift`
+
 After the repository is public, apply the baseline protection from a local admin checkout:
 
 ```powershell

--- a/scripts/github/apply-branch-protection.ps1
+++ b/scripts/github/apply-branch-protection.ps1
@@ -25,7 +25,8 @@ $requiredChecks = @(
     "workflow-lint",
     "workflow-security",
     "codeql",
-    "platform-scans"
+    "platform-scans",
+    "generated-client-drift"
 )
 
 $protection = @{

--- a/scripts/security/preflight.ps1
+++ b/scripts/security/preflight.ps1
@@ -131,7 +131,7 @@ function Invoke-PublicContentHygiene {
         'scripts/security/preflight.ps1',
         '.gitignore'
     )
-    $toneScanExcludedPathPattern = '(^|/)(scripts|\.github/workflows)(/|$)'
+    $toneScanExcludedPathPattern = '(^|/)(scripts|\.github/workflows|frontend/src/api/generated)(/|$)'
     $automationLanguagePatterns = @(
         @{ Name = "local AI/tooling reference"; Pattern = '(?i)\b(Codex|ChatGPT|Claude|OpenAI|LLM|AI[- ]?assisted|AI[- ]?generated|AI slop)\b' },
         @{ Name = "assistant instruction language"; Pattern = '(?i)\b(system prompt|developer prompt|prompt injection|assistant instructions?|agent instructions?)\b' },


### PR DESCRIPTION
## Summary

- Add a `generated-client-drift` CI job that runs for pull requests touching the runtime status contract, committed generated client output, frontend package manifests, contract-generation scripts, or the owning CI workflow.
- Keep the existing OpenAPI contract check active inside the generated-client drift gate before `contracts:check` runs.
- Update the branch-protection helper and admin checklist with the new required status check.
- Keep generated client output unchanged, and narrow local public-tone preflight so generated source stays secret-scanned without failing on upstream generator TODO comments.

Closes #20.

## Scope

This stays within Issue #20. It does not wire live frontend runtime API calls, add or change backend endpoints, change generated client output, add deployment infrastructure, add cloud credentials, or change public content or visual design.

## Verification

- `node scripts/contracts/check-openapi.mjs`
- `npm --prefix frontend run contracts:check`
- `actionlint`
- `git diff --check`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/security/preflight.ps1 -Scope Repository -RequireGitleaks`

The repository preflight ran `gitleaks` and the frontend npm audit internally. The frontend npm audit reported zero vulnerabilities.

Frontend lint, typecheck, and build were skipped because frontend package files, frontend scripts, and frontend source were not changed. Backend checks were skipped because backend implementation and backend build configuration were not changed.